### PR TITLE
Transition to a listener-based approach for the dashboard compressor toggle

### DIFF
--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -44,8 +44,6 @@ public class Robot extends TimedRobot {
     // and running subsystem periodic() methods.  This must be called from the robot's periodic
     // block in order for anything in the Command-based framework to work.
     CommandScheduler.getInstance().run();
-
-    m_robotContainer.updateCompressorStatus();
   }
 
   /** This function is called once each time the robot enters Disabled mode. */

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -104,8 +104,7 @@ public class RobotContainer {
     // Display a compressor toggle on the dashboard
     SmartDashboard.setDefaultBoolean("Compressor On?", true);
     m_compressorEnabled.addListener(
-        (event) -> {
-          // Enable or disable the compressor depending on the updated toggle value
+        event -> {
           boolean enabled = event.value.getBoolean();
           if (enabled) {
             m_pcm.enableCompressorDigital();

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -8,7 +8,6 @@ import static frc.robot.Constants.ControllerConstants.*;
 
 import edu.wpi.first.cameraserver.CameraServer;
 import edu.wpi.first.cscore.UsbCamera;
-import edu.wpi.first.networktables.EntryListenerFlags;
 import edu.wpi.first.networktables.NetworkTableEntry;
 import edu.wpi.first.util.net.PortForwarder;
 import edu.wpi.first.wpilibj.DriverStation;
@@ -23,6 +22,7 @@ import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.ParallelCommandGroup;
 import edu.wpi.first.wpilibj2.command.button.JoystickButton;
+import edu.wpi.first.wpilibj2.command.button.NetworkButton;
 import edu.wpi.first.wpilibj2.command.button.Trigger;
 import frc.robot.commands.autonomous.FiveBallAuto;
 import frc.robot.commands.autonomous.TaxiThenShoot;
@@ -69,10 +69,6 @@ public class RobotContainer {
   private final PowerDistribution m_pdp = new PowerDistribution();
   private final PneumaticsControlModule m_pcm = new PneumaticsControlModule();
 
-  // Used for toggling the compressor state (see updateCompressorState() method)
-  // private boolean m_compressorEnabled = true;
-  private final NetworkTableEntry m_compressorEnabled = SmartDashboard.getEntry("Compressor On?");
-
   // Automodes - if you add more here, add them to the chooser in setupAutoChooser()
   private final TaxiThenShoot m_taxiThenShoot =
       new TaxiThenShoot(
@@ -101,18 +97,13 @@ public class RobotContainer {
     // Silence joystick connection warnings since they're not useful
     DriverStation.silenceJoystickConnectionWarning(true);
 
-    // Display a compressor toggle on the dashboard
-    SmartDashboard.setDefaultBoolean("Compressor On?", true);
-    m_compressorEnabled.addListener(
-        event -> {
-          boolean enabled = event.value.getBoolean();
-          if (enabled) {
-            m_pcm.enableCompressorDigital();
-          } else {
-            m_pcm.disableCompressor();
-          }
-        },
-        EntryListenerFlags.kUpdate);
+    // Display a compressor toggle on the dashboard (defaults to on)
+    NetworkTableEntry compressorToggle = SmartDashboard.getEntry("Compressor On?");
+    compressorToggle.setBoolean(true);
+
+    new NetworkButton(compressorToggle)
+        .whenActive(m_pcm::enableCompressorDigital)
+        .whenInactive(m_pcm::disableCompressor);
 
     // Set default drivetrain command to arcade driving (happens during teleop)
     m_robotDrive.setDefaultCommand(

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -8,6 +8,8 @@ import static frc.robot.Constants.ControllerConstants.*;
 
 import edu.wpi.first.cameraserver.CameraServer;
 import edu.wpi.first.cscore.UsbCamera;
+import edu.wpi.first.networktables.EntryListenerFlags;
+import edu.wpi.first.networktables.NetworkTableEntry;
 import edu.wpi.first.util.net.PortForwarder;
 import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.GenericHID;
@@ -68,7 +70,8 @@ public class RobotContainer {
   private final PneumaticsControlModule m_pcm = new PneumaticsControlModule();
 
   // Used for toggling the compressor state (see updateCompressorState() method)
-  private boolean m_compressorEnabled = true;
+  // private boolean m_compressorEnabled = true;
+  private final NetworkTableEntry m_compressorEnabled = SmartDashboard.getEntry("Compressor On?");
 
   // Automodes - if you add more here, add them to the chooser in setupAutoChooser()
   private final TaxiThenShoot m_taxiThenShoot =
@@ -97,6 +100,20 @@ public class RobotContainer {
 
     // Silence joystick connection warnings since they're not useful
     DriverStation.silenceJoystickConnectionWarning(true);
+
+    // Display a compressor toggle on the dashboard
+    SmartDashboard.setDefaultBoolean("Compressor On?", true);
+    m_compressorEnabled.addListener(
+        (event) -> {
+          // Enable or disable the compressor depending on the updated toggle value
+          boolean enabled = event.value.getBoolean();
+          if (enabled) {
+            m_pcm.enableCompressorDigital();
+          } else {
+            m_pcm.disableCompressor();
+          }
+        },
+        EntryListenerFlags.kUpdate);
 
     // Set default drivetrain command to arcade driving (happens during teleop)
     m_robotDrive.setDefaultCommand(
@@ -185,19 +202,6 @@ public class RobotContainer {
 
     // Display the chooser on the dashboard
     SmartDashboard.putData(m_autoChooser);
-  }
-
-  /** Used to toggle the compressor using the dashboard. */
-  public void updateCompressorStatus() {
-    m_compressorEnabled = SmartDashboard.getBoolean("Enable Compressor", m_compressorEnabled);
-    if (m_compressorEnabled) {
-      m_pcm.enableCompressorDigital();
-    } else {
-      m_pcm.disableCompressor();
-    }
-
-    // Put the toggle onto the dashboard
-    SmartDashboard.putBoolean("Enable Compressor", m_compressorEnabled);
   }
 
   /** Retracts the climber pistons and sets them to a vertical position. */


### PR DESCRIPTION
Previously, we were enabling/disabling the compressor on every robot loop run, which wasn't really necessary. This PR takes advantage of network tables event listeners instead of repeatedly calling an update method.

I can't really simulate the compressor (or at least I don't know how to), so I'll test this on the real bot when I get a chance before merging. :)